### PR TITLE
fix(usage-info): <- adds missing `-` to that

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "btcoff"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bitcoin 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btcoff"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Greg Kapka <greg@kapka.co.uk>"]
 edition = "2018"
 

--- a/src/usage_info.rs
+++ b/src/usage_info.rs
@@ -139,7 +139,7 @@ Options:
                            hashing. A nonce of '0' will use a unix timestamp
                            instead. [default: 0]
 
-    -change=<string>    ❍ Address to send any change to. Defaults to address
+    --change=<string>    ❍ Address to send any change to. Defaults to address
                            of the private key used for the transaction.
                            [default: signer]
 


### PR DESCRIPTION
...to fix the double-default value parsing bug.